### PR TITLE
Fixed resolve & patch dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Version 0
 
+## 0.3.3
+
+* `glia.resolve` added missing `self`.
+
 ## 0.3.2
 
 * `glia.resolve` now checks installation and provides Resolver before trying to resolve.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Version 0
 
+## 0.3.2
+
+* `glia.resolve` now checks installation and provides Resolver before trying to resolve.
+
 ## 0.3.1
 
 * Fixed windows compilation process

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Version 0
 
+## 0.3.4
+
+* Finishing up resolve & wincompile issues
+
 ## 0.3.3
 
 * `glia.resolve` added missing `self`.

--- a/glia/__init__.py
+++ b/glia/__init__.py
@@ -1,6 +1,6 @@
 import os, sys
 
-__version__ = "0.3.2"
+__version__ = "0.3.3"
 
 if os.getenv("GLIA_NRN_PATH"):
     sys.path.insert(0, os.getenv("GLIA_NRN_PATH"))

--- a/glia/__init__.py
+++ b/glia/__init__.py
@@ -1,6 +1,6 @@
 import os, sys
 
-__version__ = "0.3.3"
+__version__ = "0.3.4"
 
 if os.getenv("GLIA_NRN_PATH"):
     sys.path.insert(0, os.getenv("GLIA_NRN_PATH"))

--- a/glia/__init__.py
+++ b/glia/__init__.py
@@ -1,6 +1,6 @@
 import os, sys
 
-__version__ = "0.3.1"
+__version__ = "0.3.2"
 
 if os.getenv("GLIA_NRN_PATH"):
     sys.path.insert(0, os.getenv("GLIA_NRN_PATH"))
@@ -36,7 +36,8 @@ def insert(section, asset, attributes=None, pkg=None, variant=None, x=0.5):
 
 
 def resolve(asset, pkg=None, variant=None):
-    return _manager.resolver.resolve(asset, pkg=pkg, variant=variant)
+
+    return _manager.resolve(asset, pkg=pkg, variant=variant)
 
 
 def select(asset, pkg=None, variant=None):

--- a/glia/_glia.py
+++ b/glia/_glia.py
@@ -134,7 +134,7 @@ class Glia:
         current_dir = os.getcwd()
         os.chdir(neuron_mod_path)
         process = subprocess.Popen(
-            [os.path.join(nrn_path, "nrnivmodl")],
+            [os.path.join(nrn_path, "bin", "nrnivmodl.bat")],
             stdin=subprocess.PIPE,
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
@@ -303,8 +303,8 @@ class Glia:
     def context(self, assets=None, pkg=None, variant=None):
         return self.resolver.preference_context(assets=assets, pkg=pkg, variant=variant)
 
-    @_requires_install
-    def resolve(*args, **kwargs):
+    @_requires_library
+    def resolve(self, *args, **kwargs):
         """
             Resolve the given specifications applying all preferences and return the
             full name as it is known in the library to NEURON.

--- a/glia/_glia.py
+++ b/glia/_glia.py
@@ -303,6 +303,21 @@ class Glia:
     def context(self, assets=None, pkg=None, variant=None):
         return self.resolver.preference_context(assets=assets, pkg=pkg, variant=variant)
 
+    @_requires_install
+    def resolve(*args, **kwargs):
+        """
+            Resolve the given specifications applying all preferences and return the
+            full name as it is known in the library to NEURON.
+
+            :param asset_name: Short name of the asset
+            :type asset_name: str
+            :param pkg: Package specification for the asset
+            :type pkg: str
+            :param variant: Variant specification for the asset
+            :type variant: str
+        """
+        return self.resolver.resolve(*args, **kwargs)
+
     def _load_neuron_dll(self):
         if not os.path.exists(self.get_library()):
             return

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 setuptools>=40.0.0
 packaging>=19.0
-nrn-patch>=1.3.2
+nrn-patch>=2.0.4
 requests>=2.22.0

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ deps = [
     "appdirs",
 ]
 if not os.getenv("READTHEDOCS"):
-    deps.append("nrn-patch>=2.0.1")
+    deps.append("nrn-patch>=2.0.4")
 
 
 setuptools.setup(


### PR DESCRIPTION
Resolve was first made to use `_requires_install` to provide Resolver, now uses `_requires_library` because in the use cases I've encountered resolve is usually used directly onto the HOC interpreter, but with just the install and not the library, the resolved name is not known to the HOC interpreter leading to cryptic errors.

So default behavior is now OK and advanced users can still use `glia._manager.resolver.resolve()` to avoid library loading.