### PR TITLE
v0.4 - Catalogues

### DIFF
--- a/glia/__init__.py
+++ b/glia/__init__.py
@@ -1,6 +1,6 @@
 import os, sys
 
-__version__ = "0.3.9"
+__version__ = "0.4"
 
 if os.getenv("GLIA_NRN_PATH"):
     sys.path.insert(0, os.getenv("GLIA_NRN_PATH"))
@@ -73,3 +73,13 @@ def context(assets=None, pkg=None, variant=None):
     Creates a context that sets glia preferences during a `with` statement.
     """
     return _manager.context(assets=assets, pkg=pkg, variant=variant)
+
+
+def catalogue(name):
+    """
+    Load or build an Arbor mechanism catalogue.
+
+    :param name: Name of the Glia installed Arbor catalogue.
+    :type name: str
+    """
+    return _manager.catalogue(name)

--- a/glia/_glia.py
+++ b/glia/_glia.py
@@ -432,7 +432,7 @@ class Glia:
             os.makedirs(Glia.get_cache_path())
         except FileExistsError:
             pass
-        self.resolver = Resolver(self)
+        self._resolver = Resolver(self)
         self.compile()
 
     def _add_neuron_pkg(self):

--- a/glia/_glia.py
+++ b/glia/_glia.py
@@ -215,7 +215,7 @@ class Glia:
             raise CompileError(stderr.decode("UTF-8"))
 
     def _collect_asset_state(self):
-        cache_data = self.read_cache()
+        cache_data = Glia.read_cache()
         mod_files = []
         assets = []
         # Iterate over all discovered packages to collect the mod files.
@@ -400,7 +400,7 @@ class Glia:
 
     def is_cache_fresh(self):
         try:
-            cache_data = self.read_cache()
+            cache_data = Glia.read_cache()
             hashes = cache_data["mod_hashes"]
             for pkg in self.packages:
                 if pkg.path not in hashes:
@@ -426,8 +426,8 @@ class Glia:
             os.makedirs(Glia.get_data_path())
         except FileExistsError:
             pass
-        self.create_cache()
-        self.create_preferences()
+        Glia.create_cache()
+        Glia.create_preferences()
         try:
             os.makedirs(Glia.get_cache_path())
         except FileExistsError:
@@ -468,7 +468,8 @@ class Glia:
     def get_neuron_mod_path(self, *paths):
         return Glia.get_cache_path(*paths)
 
-    def _read_shared_storage(self, *path):
+    @staticmethod
+    def _read_shared_storage(*path):
         _path = Glia.get_data_path(*path)
         try:
             with open(_path, "r") as f:
@@ -476,51 +477,60 @@ class Glia:
         except IOError:
             return {}
 
-    def _write_shared_storage(self, data, *path):
+    def _write_shared_storage(data, *path):
         _path = Glia.get_data_path(*path)
         with open(_path, "w") as f:
             f.write(json.dumps(data))
 
-    def read_storage(self, *path):
-        data = self._read_shared_storage(*path)
+    @staticmethod
+    def read_storage(*path):
+        data = Glia._read_shared_storage(*path)
         glia_path = Glia.get_glia_path()
         if glia_path not in data:
             return {}
         return data[glia_path]
 
-    def write_storage(self, data, *path):
+    @staticmethod
+    def write_storage(data, *path):
         _path = Glia.get_data_path(*path)
         glia_path = Glia.get_glia_path()
-        shared_data = self._read_shared_storage(*path)
+        shared_data = Glia._read_shared_storage(*path)
         shared_data[glia_path] = data
-        self._write_shared_storage(shared_data, *path)
+        Glia._write_shared_storage(shared_data, *path)
 
-    def read_cache(self):
-        cache = self.read_storage("cache.json")
+    @staticmethod
+    def read_cache():
+        cache = Glia.read_storage("cache.json")
         if "mod_hashes" not in cache:
             cache["mod_hashes"] = {}
         return cache
 
-    def write_cache(self, cache_data):
-        self.write_storage(cache_data, "cache.json")
+    @staticmethod
+    def write_cache(cache_data):
+        Glia.write_storage(cache_data, "cache.json")
 
-    def update_cache(self, cache_data):
-        cache = self.read_cache()
+    @staticmethod
+    def update_cache(cache_data):
+        cache = Glia.read_cache()
         cache.update(cache_data)
-        self.write_cache(cache)
+        Glia.write_cache(cache)
 
-    def create_cache(self):
+    @staticmethod
+    def create_cache():
         empty_cache = {"mod_hashes": {}}
-        self.write_cache(empty_cache)
+        Glia.write_cache(empty_cache)
 
-    def read_preferences(self):
-        return self.read_storage("preferences.json")
+    @staticmethod
+    def read_preferences():
+        return Glia.read_storage("preferences.json")
 
-    def write_preferences(self, preferences):
-        self.write_storage(preferences, "preferences.json")
+    @staticmethod
+    def write_preferences(preferences):
+        Glia.write_storage(preferences, "preferences.json")
 
-    def create_preferences(self):
-        self.write_storage({}, "preferences.json")
+    @staticmethod
+    def create_preferences():
+        Glia.write_storage({}, "preferences.json")
 
     @_requires_install
     def list_assets(self):

--- a/glia/_glia.py
+++ b/glia/_glia.py
@@ -69,14 +69,20 @@ class Glia:
         for pkg_ptr in pkg_resources.iter_entry_points("glia.package"):
             advert = pkg_ptr.load()
             self.entry_points.append(advert)
-            self.packages.append(Package.from_remote(self, advert))
+            self._packages.append(Package.from_remote(self, advert))
 
     def discover_catalogues(self):
-        _replace_attr(self, "catalogues", [])
+        self._catalogues = {}
         for pkg_ptr in pkg_resources.iter_entry_points("glia.catalogue"):
             advert = pkg_ptr.load()
             self.entry_points.append(advert)
-            self.catalogues.append(advert)
+            if advert.name in self._catalogues:
+                raise RuntimeError(
+                    f"Duplicate installations of `{advert.name}` catalogue:"
+                    + f"\n{self._catalogues[advert.name].path}"
+                    + f"\n{advert.path}"
+                )
+            self._catalogues[advert.name] = advert
 
     def catalogue(self, name):
         import arbor

--- a/glia/assets.py
+++ b/glia/assets.py
@@ -2,7 +2,9 @@ import os
 from .exceptions import PackageError, PackageModError, PackageVersionError
 from packaging import version
 from ._glia import Glia
+from ._hash import get_directory_hash
 import subprocess
+import shutil
 from tempfile import TemporaryDirectory
 
 
@@ -123,20 +125,34 @@ class Mod:
 
 
 class Catalogue:
-    def __init__(self, name):
+    def __init__(self, name, source_file):
         self._name = name
-        self._path = Glia.get_cache_path(self._name, for_arbor=True)
+        self._source = os.path.dirname(source_file)
+        self._cache = Glia.get_cache_path(self._name, for_arbor=True)
+
+    @property
+    def name(self):
+        return self._name
+
+    @property
+    def source(self):
+        return self._source
 
     def load(self):
         import arbor
 
         if not self.is_fresh():
             self.build()
-        return arbor.load_catalogue(os.path.join(self._path, f"{self._name}.so"))
+        return arbor.load_catalogue(self._get_library_path())
+
+    def _get_library_path(self):
+        return os.path.join(self._cache, f"{self._name}-catalogue.so")
 
     def is_fresh(self):
+        if not os.path.exists(self._get_library_path()):
+            return False
         try:
-            cache_data = self.read_cache()
+            cache_data = Glia.read_cache()
             # Backward compatibility with old installs that
             # have a JSON file without cat_hashes in it.
             cache = cache_data.get("cat_hashes", dict()).get(self._name, None)
@@ -146,21 +162,39 @@ class Catalogue:
             return False
 
     def get_mod_path(self):
-        return os.path.abspath(os.path.join(self._path, "mod"))
+        return os.path.abspath(os.path.join(self._source, "mod"))
 
-    def build(self, verbose=True):
+    def build(self, verbose=False):
+        try:
+            from mpi4py.MPI import COMM_WORLD
+
+            mpi = True
+            if COMM_WORLD.Get_rank():
+                COMM_WORLD.Barrier()
+                return
+        except:
+            mpi = False
+
         mod_path = self.get_mod_path()
         with TemporaryDirectory() as tmp:
+            pwd = os.getcwd()
+            os.chdir(tmp)
             subprocess.run(
                 f"build-catalogue {self._name} {mod_path}"
+                + (" --quiet" if not verbose else "")
                 + (" --verbose" if verbose else ""),
                 shell=True,
                 check=True,
                 capture_output=not verbose,
             )
-            shutil.copy2(f"{self._name}-catalogue.so", self._path)
+            os.makedirs(self._cache, exist_ok=True)
+            shutil.copy2(f"{self._name}-catalogue.so", self._cache)
+            os.chdir(pwd)
         # Cache directory hash of current mod files so we only rebuild on source code changes.
-        cache_data = self.read_cache()
+        cache_data = Glia.read_cache()
         cat_hashes = cache_data.setdefault("cat_hashes", dict())
         cat_hashes[self._name] = get_directory_hash(mod_path)
-        self.update_cache(cache_data)
+        Glia.update_cache(cache_data)
+
+        if mpi:
+            COMM_WORLD.Barrier()

--- a/glia/assets.py
+++ b/glia/assets.py
@@ -1,6 +1,9 @@
 import os
 from .exceptions import PackageError, PackageModError, PackageVersionError
 from packaging import version
+from ._glia import Glia
+import subprocess
+from tempfile import TemporaryDirectory
 
 
 class Package:
@@ -117,3 +120,47 @@ class Mod:
     @property
     def mod_path(self):
         return os.path.abspath(os.path.join(self.pkg.mod_path, self.mod_name + ".mod"))
+
+
+class Catalogue:
+    def __init__(self, name):
+        self._name = name
+        self._path = Glia.get_cache_path(self._name, for_arbor=True)
+
+    def load(self):
+        import arbor
+
+        if not self.is_fresh():
+            self.build()
+        return arbor.load_catalogue(os.path.join(self._path, f"{self._name}.so"))
+
+    def is_fresh(self):
+        try:
+            cache_data = self.read_cache()
+            # Backward compatibility with old installs that
+            # have a JSON file without cat_hashes in it.
+            cache = cache_data.get("cat_hashes", dict()).get(self._name, None)
+            hash = get_directory_hash(self.get_mod_path())
+            return cache == hash
+        except FileNotFoundError as _:
+            return False
+
+    def get_mod_path(self):
+        return os.path.abspath(os.path.join(self._path, "mod"))
+
+    def build(self, verbose=True):
+        mod_path = self.get_mod_path()
+        with TemporaryDirectory() as tmp:
+            subprocess.run(
+                f"build-catalogue {self._name} {mod_path}"
+                + (" --verbose" if verbose else ""),
+                shell=True,
+                check=True,
+                capture_output=not verbose,
+            )
+            shutil.copy2(f"{self._name}-catalogue.so", self._path)
+        # Cache directory hash of current mod files so we only rebuild on source code changes.
+        cache_data = self.read_cache()
+        cat_hashes = cache_data.setdefault("cat_hashes", dict())
+        cat_hashes[self._name] = get_directory_hash(mod_path)
+        self.update_cache(cache_data)

--- a/glia/resolution.py
+++ b/glia/resolution.py
@@ -42,7 +42,6 @@ class Resolver:
         self.local_preferences = {}
         self.__preference_stack = {}
         self.__next_stack_id = 0
-        # self.index = self._manager.read_index()
         self.construct_index()
 
     def construct_index(self):


### PR DESCRIPTION
Arbor catalogues can now be shipped through `pip`. `astrocyte` still has to be merged into `glia` to make the packaging user friendly.